### PR TITLE
Fix Docker build failing due to unavailable servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y git redis libgeos-dev && \
+    apt-get install -y git redis libgeos-dev gdal-bin libgdal-dev g++ && \
     rm -rf /var/cache/apt/lists
 
 # Port setup
@@ -25,8 +25,10 @@ RUN cd /app && \
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 # download data for a local authority (Newcastle by default)
+# previous servers unavailable so just copy from local copy in repo
 ARG LAD20CD=E08000021 
 ENV LAD20CD=$LAD20CD
-RUN python /app/spineq/data_fetcher.py --lad20cd $LAD20CD
+ENV SPINEQ_HOME=/app
+COPY data/processed/$LAD20CD $SPINEQ_HOME/data/processed/$LAD20CD
 
 WORKDIR /app/api

--- a/api/app.py
+++ b/api/app.py
@@ -436,5 +436,4 @@ def delete_job(job_id):
 
 
 if __name__ == "__main__":
-    # app.run(host=FLASK_HOST, port=FLASK_PORT)
     socketio.run(app, host=FLASK_HOST, port=FLASK_PORT)

--- a/api/app.py
+++ b/api/app.py
@@ -1,6 +1,7 @@
 """Creates the Flask and Flask-Socketio endpoints for the
 optimisation backend.
 """
+
 import pandas as pd
 import rq
 from config import FLASK_HOST, FLASK_PORT, REDIS_HOST, REDIS_PORT
@@ -17,7 +18,13 @@ redis_url = "redis://{}:{}".format(REDIS_HOST, REDIS_PORT)
 
 app = Flask(__name__)
 CORS(app)
-socketio = SocketIO(app, cors_allowed_origins="*", message_queue=redis_url)
+socketio = SocketIO(
+    app,
+    cors_allowed_origins="*",
+    message_queue=redis_url,
+    logger=True,
+    engineio_logger=True,
+)
 
 
 @app.route("/")
@@ -429,4 +436,5 @@ def delete_job(job_id):
 
 
 if __name__ == "__main__":
-    app.run(host=FLASK_HOST, port=FLASK_PORT)
+    # app.run(host=FLASK_HOST, port=FLASK_PORT)
+    socketio.run(app, host=FLASK_HOST, port=FLASK_PORT)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   web:
     build: .
-    container_name: spineq_api
+    container_name: spineq-api
     ports:
       - "${HOST_PORT}:${FLASK_PORT}"
     depends_on:
@@ -16,7 +16,7 @@ services:
 
   worker:
     build: .
-    container_name: spineq_worker
+    container_name: spineq-worker
     depends_on:
       - redis
     env_file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ eventlet = {version = "^0.33.1", optional = true}
 platformdirs = "^2.5.2"
 openpyxl = "^3.0.10"
 pygeos = "^0.12.0"
+dnspython = ">1, <2"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
Copy data to the container from the repo instead, which has a backup of the data used previously (which no longer seems to be available at the links used originally).

Also downgrade `dnspython<2` due to some errors that seemed a bit like this: https://github.com/eventlet/eventlet/issues/629 (but haven't dug into it properly).